### PR TITLE
Resolve drag-to-archive issue by adding missing server route handlers…

### DIFF
--- a/bugs/archive-drag-drop-not-working.json
+++ b/bugs/archive-drag-drop-not-working.json
@@ -3,8 +3,12 @@
     "cohort": "c26",
     "repo": "kanban-local1"
   },
+  "status": "resolved",
+  "resolved_at": "2026-03-07",
   "summary": "Enable drag-to-archive task on Kanban board",
   "problem_statement": "Users cannot archive tasks by dragging them to the archive zone at the bottom of the Kanban board. The archive zone is visible and shows \"Drag here to archive\" but dropping a task on it does not trigger the archive action. The task either snaps back to its original position or the drop is not registered. This blocks users from using the primary archive workflow and forces them to use alternative methods if any exist.\n\nCollision detection may be failing to identify when the dragged item overlaps the archive droppable. The pointerWithin algorithm can have issues with droppables in scrollable containers. The archive zone may be competing with SortableContext droppables or not receiving collision events when the dragged item's rect intersects it.",
+  "root_cause": "The server-side Express route handlers for archive endpoints were never registered in server/routes.ts. The shared route config (shared/routes.ts) defines GET /api/tasks/archived, POST /api/tasks/:id/archive, and POST /api/tasks/:id/unarchive. The client hook (useArchiveTask) correctly calls these endpoints. The storage layer (storage.ts) implements archiveTask(), unarchiveTask(), and getArchivedTasks(). But the Express app never wired up the handlers, so all archive API calls returned 404. The client-side collision detection and drag handling were working correctly the entire time - the task would be detected over the archive zone, handleDragEnd would fire the mutation, but the server would 404, triggering the onError rollback that re-added the task to the board (making it appear to 'snap back'). The prior fix (commit 684fe5f) incorrectly diagnosed the issue as a client-side collision detection problem.",
+  "fix_applied": "Added the three missing route handlers to server/routes.ts: GET /api/tasks/archived (list archived tasks), POST /api/tasks/:id/archive (archive a task), POST /api/tasks/:id/unarchive (unarchive a task). These wire up to the existing storage methods that were already implemented.",
   "in_scope": [
     "Investigate why archive zone droppable is not receiving drop events",
     "Fix collision detection to reliably detect archive zone when dragged item overlaps it",
@@ -30,11 +34,13 @@
   "dependencies": [
     "dnd-kit core and sortable packages",
     "ArchiveZone component at client/src/components/ArchiveZone.tsx",
-    "KanbanBoard collision detection at client/src/components/KanbanBoard.tsx"
+    "KanbanBoard collision detection at client/src/components/KanbanBoard.tsx",
+    "Server route handlers at server/routes.ts",
+    "Storage methods at server/storage.ts"
   ],
   "risks": [
     "dnd-kit collision detection behavior may differ across scroll containers",
     "Touch drag on mobile may require different activation or collision handling"
   ],
-  "implementation_notes": "KanbanBoard uses custom collision detection: rectIntersection is run first for archive containers only, then pointerWithin for columns, then closestCenter. ArchiveZone uses useDroppable with id 'archive'. Check that droppableContainers includes the archive when filtering. Consider rectIntersection using the dragged item's collisionRect. Reference: https://docs.dndkit.com/api-documentation/context-provider/collision-detection-algorithms. Files: client/src/components/KanbanBoard.tsx (handleDragEnd, collisionDetection), client/src/components/ArchiveZone.tsx, client/src/hooks/use-tasks.ts (useArchiveTask)."
+  "implementation_notes": "The original bug diagnosis focused on client-side dnd-kit collision detection (pointerWithin vs rectIntersection, MeasuringStrategy). The actual issue was a missing backend wiring: the Express route handlers for archive/unarchive/archived-list were never registered despite the storage layer, shared route config, and client hooks all being correctly implemented. The client-side DnD code (custom collision detection prioritizing archive zone, handleDragEnd archive check, optimistic update with rollback) was working correctly. Files changed: server/routes.ts (added 3 route handlers)."
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -92,6 +92,35 @@ export async function registerRoutes(
     res.status(204).send();
   });
 
+  app.get(api.tasks.archived.path, async (_req, res) => {
+    const archivedTasks = await storage.getArchivedTasks();
+    res.json(archivedTasks);
+  });
+
+  app.post(api.tasks.archive.path, async (req, res) => {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({ message: "Invalid ID" });
+    }
+    const task = await storage.archiveTask(id);
+    if (!task) {
+      return res.status(404).json({ message: "Task not found" });
+    }
+    res.json(task);
+  });
+
+  app.post(api.tasks.unarchive.path, async (req, res) => {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({ message: "Invalid ID" });
+    }
+    const task = await storage.unarchiveTask(id);
+    if (!task) {
+      return res.status(404).json({ message: "Task not found" });
+    }
+    res.json(task);
+  });
+
   // Stage endpoints
   app.get(api.stages.list.path, async (_req, res) => {
     const allStages = await storage.getStages();


### PR DESCRIPTION
… for archiving tasks. Updated the status of the bug to resolved and clarified the root cause and fix applied in the JSON file. This ensures proper handling of archive actions in the Kanban board.