### PR TITLE
Refactor stage data fetching to use custom hooks

### DIFF
--- a/client/src/components/CreateTaskDialog.tsx
+++ b/client/src/components/CreateTaskDialog.tsx
@@ -4,8 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { insertTaskSchema, type InsertTask } from '@shared/schema';
 import { useCreateTask } from '@/hooks/use-tasks';
 import { useToast } from '@/hooks/use-toast';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@shared/routes';
+import { useStages } from '@/hooks/use-stages';
 import {
   Dialog,
   DialogContent,
@@ -44,28 +43,7 @@ export function CreateTaskDialog({ iconOnly = false }: CreateTaskDialogProps) {
   const { toast } = useToast();
   const createTask = useCreateTask();
 
-  const { data: stages = [] } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [] } = useStages();
 
   const defaultStageId = stages[0]?.id || 1;
 

--- a/client/src/components/EditTaskDialog.tsx
+++ b/client/src/components/EditTaskDialog.tsx
@@ -4,8 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { insertTaskSchema, type InsertTask, type Task } from '@shared/schema';
 import { useUpdateTask, useDeleteTask } from '@/hooks/use-tasks';
 import { useToast } from '@/hooks/use-toast';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@shared/routes';
+import { useStages } from '@/hooks/use-stages';
 import {
   Dialog,
   DialogContent,
@@ -62,28 +61,7 @@ export function EditTaskDialog({ task, open, onOpenChange, onViewHistory }: Edit
   const updateTask = useUpdateTask();
   const deleteTask = useDeleteTask();
 
-  const { data: stages = [] } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [] } = useStages();
 
   const form = useForm<InsertTask>({
     resolver: zodResolver(insertTaskSchema),

--- a/client/src/components/KanbanBoard.tsx
+++ b/client/src/components/KanbanBoard.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-misused-promises, @typescript-eslint/no-floating-promises, @typescript-eslint/no-confusing-void-expression, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/return-await, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unnecessary-boolean-literal-compare, @typescript-eslint/require-await, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion, @typescript-eslint/prefer-optional-chain -- R2 baseline: strict fixes deferred to follow-up tasks */
 import { useEffect, useMemo, useState } from 'react';
 import { Task } from '@shared/schema';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@shared/routes';
+import { useStages, useSubStages } from '@/hooks/use-stages';
 import {
   DndContext,
   DragOverlay,
@@ -47,51 +46,9 @@ export function KanbanBoard({
   const [activeTasks, setActiveTasks] = useState(tasks);
   const [isOverArchive, setIsOverArchive] = useState(false);
 
-  const { data: stages = [] } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [] } = useStages();
 
-  const { data: allSubStages = [] } = useQuery({
-    queryKey: [api.subStages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.subStages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch sub-stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: allSubStages = [] } = useSubStages();
 
   useEffect(() => {
     setActiveTasks(tasks);

--- a/client/src/components/StageHeaders.tsx
+++ b/client/src/components/StageHeaders.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-misused-promises, @typescript-eslint/no-floating-promises, @typescript-eslint/no-confusing-void-expression, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/return-await, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unnecessary-boolean-literal-compare, @typescript-eslint/require-await, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion, @typescript-eslint/prefer-optional-chain -- R2 baseline: strict fixes deferred to follow-up tasks */
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@shared/routes';
 import { Task } from '@shared/schema';
+import { useStages } from '@/hooks/use-stages';
 import { Badge } from '@/components/ui/badge';
 
 interface StageHeadersProps {
@@ -27,28 +26,7 @@ const getDefaultStageColor = (index: number): string => {
 };
 
 export function StageHeaders({ tasks }: StageHeadersProps) {
-  const { data: stages = [] } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [] } = useStages();
 
   const sortedStages = useMemo(() => {
     return [...stages].sort((a: any, b: any) => a.order - b.order);

--- a/client/src/components/TaskWarnings.tsx
+++ b/client/src/components/TaskWarnings.tsx
@@ -4,36 +4,14 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { AlertCircle, Clock } from 'lucide-react';
 import { isPast, isToday, differenceInDays } from 'date-fns';
 import { cn } from '@/lib/utils';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@shared/routes';
+import { useStages } from '@/hooks/use-stages';
 
 interface TaskWarningsProps {
   tasks: Task[];
 }
 
 export function TaskWarnings({ tasks }: TaskWarningsProps) {
-  const { data: stages = [] } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [] } = useStages();
 
   const activeTasks = tasks.filter((t) => !t.archived);
 

--- a/client/src/hooks/use-stages.ts
+++ b/client/src/hooks/use-stages.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-misused-promises, @typescript-eslint/no-floating-promises, @typescript-eslint/no-confusing-void-expression, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/return-await, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unnecessary-boolean-literal-compare, @typescript-eslint/require-await, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion, @typescript-eslint/prefer-optional-chain -- R2 baseline: strict fixes deferred to follow-up tasks */
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@shared/routes';
+import type { Stage, SubStage } from '@shared/schema';
+
+export function useStages() {
+  return useQuery<Stage[]>({
+    queryKey: [api.stages.list.path],
+    queryFn: async () => {
+      try {
+        const res = await fetch(api.stages.list.path);
+        if (!res.ok) {
+          const errorText = await res.text();
+          throw new Error(
+            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
+          );
+        }
+        return res.json();
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch')) {
+          throw new Error(
+            'Network error: Unable to connect to server. Please check if the server is running.',
+          );
+        }
+        throw error;
+      }
+    },
+  });
+}
+
+export function useSubStages() {
+  return useQuery<SubStage[]>({
+    queryKey: [api.subStages.list.path],
+    queryFn: async () => {
+      try {
+        const res = await fetch(api.subStages.list.path);
+        if (!res.ok) {
+          const errorText = await res.text();
+          throw new Error(
+            `Failed to fetch sub-stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
+          );
+        }
+        return res.json();
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch')) {
+          throw new Error(
+            'Network error: Unable to connect to server. Please check if the server is running.',
+          );
+        }
+        throw error;
+      }
+    },
+  });
+}

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-misused-promises, @typescript-eslint/no-floating-promises, @typescript-eslint/no-confusing-void-expression, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/return-await, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unnecessary-boolean-literal-compare, @typescript-eslint/require-await, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion, @typescript-eslint/prefer-optional-chain -- R2 baseline: strict fixes deferred to follow-up tasks */
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useLocation } from 'wouter';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -26,6 +26,7 @@ import { queryClient, apiRequest } from '@/lib/queryClient';
 import { Trash2, Edit, ChevronLeft, Settings } from 'lucide-react';
 import { ColorPicker } from '@/components/ColorPicker';
 import { useState } from 'react';
+import { useStages, useSubStages } from '@/hooks/use-stages';
 import {
   Select,
   SelectContent,
@@ -46,51 +47,9 @@ export default function Admin(_props: AdminProps) {
   const [subStageDialogOpen, setSubStageDialogOpen] = useState(false);
   const [selectedStageId, setSelectedStageId] = useState<number | null>(null);
 
-  const { data: stages = [], isLoading } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [], isLoading } = useStages();
 
-  const { data: subStages = [] } = useQuery({
-    queryKey: [api.subStages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.subStages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch sub-stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: subStages = [] } = useSubStages();
 
   const createMutation = useMutation({
     mutationFn: async (data: InsertStage) => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -25,9 +25,9 @@ import {
 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { useQuery } from '@tanstack/react-query';
 import { api } from '@shared/routes';
 import { useToast } from '@/hooks/use-toast';
+import { useStages } from '@/hooks/use-stages';
 import { cn } from '@/lib/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- page component; props will grow during Phase 5 decomposition
@@ -46,28 +46,7 @@ export default function Dashboard(_props: DashboardProps) {
   const [focusMode, setFocusMode] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
-  const { data: stages = [] } = useQuery({
-    queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
-  });
+  const { data: stages = [] } = useStages();
 
   // Keyboard shortcuts
   useKeyboardShortcuts({


### PR DESCRIPTION
- Replaced direct use of `useQuery` for fetching stages in multiple components (CreateTaskDialog, EditTaskDialog, KanbanBoard, StageHeaders, TaskWarnings, Admin, Dashboard) with a new `useStages` hook for improved code reusability and maintainability.
- Introduced `useSubStages` hook for fetching sub-stages, enhancing the modularity of data fetching logic.