### PR TITLE
Refactor API calls in hooks to use centralized API functions

### DIFF
--- a/client/src/hooks/use-stages.ts
+++ b/client/src/hooks/use-stages.ts
@@ -2,53 +2,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@shared/routes';
 import type { Stage, SubStage } from '@shared/schema';
+import { apiGet } from '@/lib/api';
 
 export function useStages() {
   return useQuery<Stage[]>({
     queryKey: [api.stages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.stages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
+    queryFn: () => apiGet<Stage[]>(api.stages.list.path),
   });
 }
 
 export function useSubStages() {
   return useQuery<SubStage[]>({
     queryKey: [api.subStages.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.subStages.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch sub-stages: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return res.json();
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
+    queryFn: () => apiGet<SubStage[]>(api.subStages.list.path),
   });
 }

--- a/client/src/hooks/use-tasks.ts
+++ b/client/src/hooks/use-tasks.ts
@@ -1,63 +1,20 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-misused-promises, @typescript-eslint/no-floating-promises, @typescript-eslint/no-confusing-void-expression, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/return-await, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unnecessary-boolean-literal-compare, @typescript-eslint/require-await, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion, @typescript-eslint/prefer-optional-chain -- R2 baseline: strict fixes deferred to follow-up tasks */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api, type InsertTask } from '@shared/routes';
-import { Task } from '@shared/schema';
+import type { Task } from '@shared/schema';
+import { apiGet, apiPost, apiPatch, apiDelete } from '@/lib/api';
 
 export function useTasks() {
   return useQuery({
     queryKey: [api.tasks.list.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.tasks.list.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch tasks: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return api.tasks.list.responses[200].parse(await res.json());
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
+    queryFn: () => apiGet<Task[]>(api.tasks.list.path),
   });
 }
 
 export function useCreateTask() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (task: InsertTask) => {
-      try {
-        const res = await fetch(api.tasks.create.path, {
-          method: api.tasks.create.method,
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(task),
-        });
-        if (!res.ok) {
-          let errorMessage = 'Failed to create task';
-          try {
-            const error = await res.json();
-            errorMessage = error.message || errorMessage;
-          } catch {
-            errorMessage = `${res.status} ${res.statusText}`;
-          }
-          throw new Error(errorMessage);
-        }
-        return api.tasks.create.responses[201].parse(await res.json());
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
+    mutationFn: (task: InsertTask) => apiPost<Task>(api.tasks.create.path, task),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.tasks.list.path] });
     },
@@ -67,35 +24,9 @@ export function useCreateTask() {
 export function useUpdateTask() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, ...updates }: { id: number } & Partial<InsertTask>) => {
-      try {
-        const url = api.tasks.update.path.replace(':id', id.toString());
-
-        const res = await fetch(url, {
-          method: api.tasks.update.method,
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(updates),
-        });
-
-        if (!res.ok) {
-          let errorMessage = 'Failed to update task';
-          try {
-            const error = await res.json();
-            errorMessage = error.message || errorMessage;
-          } catch {
-            errorMessage = `${res.status} ${res.statusText}`;
-          }
-          throw new Error(errorMessage);
-        }
-        return api.tasks.update.responses[200].parse(await res.json());
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
+    mutationFn: ({ id, ...updates }: { id: number } & Partial<InsertTask>) => {
+      const url = api.tasks.update.path.replace(':id', id.toString());
+      return apiPatch<Task>(url, updates);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.tasks.list.path] });
@@ -106,31 +37,9 @@ export function useUpdateTask() {
 export function useDeleteTask() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: number) => {
-      try {
-        const url = api.tasks.delete.path.replace(':id', id.toString());
-        const res = await fetch(url, {
-          method: api.tasks.delete.method,
-        });
-
-        if (!res.ok) {
-          let errorMessage = 'Failed to delete task';
-          try {
-            const error = await res.json();
-            errorMessage = error.message || errorMessage;
-          } catch {
-            errorMessage = `${res.status} ${res.statusText}`;
-          }
-          throw new Error(errorMessage);
-        }
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
+    mutationFn: (id: number) => {
+      const url = api.tasks.delete.path.replace(':id', id.toString());
+      return apiDelete(url);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.tasks.list.path] });
@@ -141,56 +50,16 @@ export function useDeleteTask() {
 export function useArchivedTasks() {
   return useQuery({
     queryKey: [api.tasks.archived.path],
-    queryFn: async () => {
-      try {
-        const res = await fetch(api.tasks.archived.path);
-        if (!res.ok) {
-          const errorText = await res.text();
-          throw new Error(
-            `Failed to fetch archived tasks: ${res.status} ${res.statusText}${errorText ? ` - ${errorText}` : ''}`,
-          );
-        }
-        return api.tasks.archived.responses[200].parse(await res.json());
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
-    },
+    queryFn: () => apiGet<Task[]>(api.tasks.archived.path),
   });
 }
 
 export function useArchiveTask() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: number) => {
-      try {
-        const url = api.tasks.archive.path.replace(':id', id.toString());
-        const res = await fetch(url, {
-          method: api.tasks.archive.method,
-        });
-        if (!res.ok) {
-          let errorMessage = 'Failed to archive task';
-          try {
-            const error = await res.json();
-            errorMessage = error.message || errorMessage;
-          } catch {
-            errorMessage = `${res.status} ${res.statusText}`;
-          }
-          throw new Error(errorMessage);
-        }
-        return api.tasks.archive.responses[200].parse(await res.json());
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
+    mutationFn: (id: number) => {
+      const url = api.tasks.archive.path.replace(':id', id.toString());
+      return apiPost<Task>(url);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.tasks.list.path] });
@@ -202,31 +71,9 @@ export function useArchiveTask() {
 export function useUnarchiveTask() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: number) => {
-      try {
-        const url = api.tasks.unarchive.path.replace(':id', id.toString());
-        const res = await fetch(url, {
-          method: api.tasks.unarchive.method,
-        });
-        if (!res.ok) {
-          let errorMessage = 'Failed to unarchive task';
-          try {
-            const error = await res.json();
-            errorMessage = error.message || errorMessage;
-          } catch {
-            errorMessage = `${res.status} ${res.statusText}`;
-          }
-          throw new Error(errorMessage);
-        }
-        return api.tasks.unarchive.responses[200].parse(await res.json());
-      } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch')) {
-          throw new Error(
-            'Network error: Unable to connect to server. Please check if the server is running.',
-          );
-        }
-        throw error;
-      }
+    mutationFn: (id: number) => {
+      const url = api.tasks.unarchive.path.replace(':id', id.toString());
+      return apiPost<Task>(url);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.tasks.list.path] });

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,85 @@
+import type { ApiErrorResponse } from '@shared/api-types';
+
+/** Consistent error type thrown by apiRequest on non-OK responses */
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+  ) {
+    super(`${status}: ${body || statusText}`);
+    this.name = 'ApiError';
+  }
+}
+
+type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+
+interface ApiRequestOptions {
+  method?: HttpMethod;
+  body?: unknown;
+}
+
+/**
+ * Typed API request wrapper that centralises fetch, headers, JSON parsing,
+ * and error handling for all client-side API calls.
+ *
+ * @example
+ *   const tasks = await apiRequest<Task[]>('/api/tasks');
+ *   const task  = await apiRequest<Task>('/api/tasks', { method: 'POST', body: newTask });
+ */
+export async function apiRequest<T = void>(
+  url: string,
+  options: ApiRequestOptions = {},
+): Promise<T> {
+  const { method = 'GET', body } = options;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      credentials: 'include',
+    });
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new Error(
+        'Network error: Unable to connect to server. Please check if the server is running.',
+      );
+    }
+    throw error;
+  }
+
+  if (!res.ok) {
+    let errorBody: string;
+    try {
+      const json = (await res.json()) as ApiErrorResponse;
+      errorBody = json.message || JSON.stringify(json);
+    } catch {
+      errorBody = (await res.text()) || res.statusText;
+    }
+    throw new ApiError(res.status, res.statusText, errorBody);
+  }
+
+  if (res.status === 204 || res.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
+
+  return (await res.json()) as T;
+}
+
+export function apiGet<T>(url: string): Promise<T> {
+  return apiRequest<T>(url);
+}
+
+export function apiPost<T = void>(url: string, body?: unknown): Promise<T> {
+  return apiRequest<T>(url, { method: 'POST', body });
+}
+
+export function apiPatch<T>(url: string, body: unknown): Promise<T> {
+  return apiRequest<T>(url, { method: 'PATCH', body });
+}
+
+export function apiDelete(url: string): Promise<void> {
+  return apiRequest(url, { method: 'DELETE' });
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,63 +1,25 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-misused-promises, @typescript-eslint/no-floating-promises, @typescript-eslint/no-confusing-void-expression, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/return-await, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unnecessary-boolean-literal-compare, @typescript-eslint/require-await, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion, @typescript-eslint/prefer-optional-chain -- R2 baseline: strict fixes deferred to follow-up tasks */
-import { QueryClient, QueryFunction } from '@tanstack/react-query';
+/* eslint-disable @typescript-eslint/no-unsafe-return -- generic T propagation through apiGet is type-safe at call sites */
+import { QueryClient, type QueryFunction } from '@tanstack/react-query';
+import { apiGet, ApiError } from './api';
 
-async function throwIfResNotOk(res: Response) {
-  if (!res.ok) {
-    const text = (await res.text()) || res.statusText;
-    throw new Error(`${res.status}: ${text}`);
-  }
-}
-
-export async function apiRequest(method: string, url: string, data?: unknown): Promise<Response> {
-  const operation =
-    method === 'POST'
-      ? 'CREATE'
-      : method === 'PATCH'
-        ? 'UPDATE'
-        : method === 'DELETE'
-          ? 'DELETE'
-          : 'REQUEST';
-  const logPrefix = `[CLIENT_API] [${operation}_STAGE]`;
-
-  console.log(`${logPrefix} Preparing request:`, {
-    method,
-    url,
-    data: data ? JSON.stringify(data) : undefined,
-  });
-
-  const res = await fetch(url, {
-    method,
-    headers: data ? { 'Content-Type': 'application/json' } : {},
-    body: data ? JSON.stringify(data) : undefined,
-    credentials: 'include',
-  });
-
-  console.log(`${logPrefix} Response received:`, {
-    status: res.status,
-    statusText: res.statusText,
-    ok: res.ok,
-  });
-
-  await throwIfResNotOk(res);
-
-  console.log(`${logPrefix} Response validation passed`);
-  return res;
-}
+export { apiRequest, apiGet, apiPost, apiPatch, apiDelete, ApiError } from './api';
 
 type UnauthorizedBehavior = 'returnNull' | 'throw';
 export const getQueryFn: <T>(options: { on401: UnauthorizedBehavior }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join('/'), {
-      credentials: 'include',
-    });
-
-    if (unauthorizedBehavior === 'returnNull' && res.status === 401) {
-      return null;
+    try {
+      return await apiGet<T>(queryKey.join('/'));
+    } catch (error) {
+      if (
+        unauthorizedBehavior === 'returnNull' &&
+        error instanceof ApiError &&
+        error.status === 401
+      ) {
+        return null as T;
+      }
+      throw error;
     }
-
-    await throwIfResNotOk(res);
-    return await res.json();
   };
 
 export const queryClient = new QueryClient({

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -21,8 +21,11 @@ import {
   insertSubStageSchema,
   type InsertStage,
   type InsertSubStage,
+  type Stage,
+  type SubStage,
 } from '@shared/schema';
-import { queryClient, apiRequest } from '@/lib/queryClient';
+import { queryClient } from '@/lib/queryClient';
+import { apiPost, apiPatch, apiDelete } from '@/lib/api';
 import { Trash2, Edit, ChevronLeft, Settings } from 'lucide-react';
 import { ColorPicker } from '@/components/ColorPicker';
 import { useState } from 'react';
@@ -52,10 +55,7 @@ export default function Admin(_props: AdminProps) {
   const { data: subStages = [] } = useSubStages();
 
   const createMutation = useMutation({
-    mutationFn: async (data: InsertStage) => {
-      const response = await apiRequest(api.stages.create.method, api.stages.create.path, data);
-      return response.json();
-    },
+    mutationFn: (data: InsertStage) => apiPost<Stage>(api.stages.create.path, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.stages.list.path] });
       queryClient.refetchQueries({ queryKey: [api.stages.list.path] });
@@ -66,10 +66,9 @@ export default function Admin(_props: AdminProps) {
   });
 
   const updateMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: number; data: Partial<InsertStage> }) => {
+    mutationFn: ({ id, data }: { id: number; data: Partial<InsertStage> }) => {
       const url = api.stages.update.path.replace(':id', String(id));
-      const response = await apiRequest(api.stages.update.method, url, data);
-      return response.json();
+      return apiPatch<Stage>(url, data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.stages.list.path] });
@@ -88,9 +87,9 @@ export default function Admin(_props: AdminProps) {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: async (id: number) => {
+    mutationFn: (id: number) => {
       const url = api.stages.delete.path.replace(':id', String(id));
-      return apiRequest(api.stages.delete.method, url);
+      return apiDelete(url);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.stages.list.path] });
@@ -123,14 +122,7 @@ export default function Admin(_props: AdminProps) {
   });
 
   const createSubStageMutation = useMutation({
-    mutationFn: async (data: InsertSubStage) => {
-      const response = await apiRequest(
-        api.subStages.create.method,
-        api.subStages.create.path,
-        data,
-      );
-      return response.json();
-    },
+    mutationFn: (data: InsertSubStage) => apiPost<SubStage>(api.subStages.create.path, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.subStages.list.path] });
       toast({ description: 'Sub-stage created' });
@@ -153,10 +145,9 @@ export default function Admin(_props: AdminProps) {
   });
 
   const updateSubStageMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: number; data: Partial<InsertSubStage> }) => {
+    mutationFn: ({ id, data }: { id: number; data: Partial<InsertSubStage> }) => {
       const url = api.subStages.update.path.replace(':id', String(id));
-      const response = await apiRequest(api.subStages.update.method, url, data);
-      return response.json();
+      return apiPatch<SubStage>(url, data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.subStages.list.path] });
@@ -181,9 +172,9 @@ export default function Admin(_props: AdminProps) {
   });
 
   const deleteSubStageMutation = useMutation({
-    mutationFn: async (id: number) => {
+    mutationFn: (id: number) => {
       const url = api.subStages.delete.path.replace(':id', String(id));
-      return apiRequest(api.subStages.delete.method, url);
+      return apiDelete(url);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [api.subStages.list.path] });

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -8,7 +8,8 @@ import { TaskHistoryModal } from '@/components/TaskHistoryModal';
 import { TaskWarnings } from '@/components/TaskWarnings';
 import { StageHeaders } from '@/components/StageHeaders';
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
-import { Task, type InsertTask } from '@shared/schema';
+import { type Task, type InsertTask, type Stage } from '@shared/schema';
+import { apiGet } from '@/lib/api';
 import {
   Loader2,
   LayoutDashboard,
@@ -143,18 +144,15 @@ export default function Dashboard(_props: DashboardProps) {
 
           let stagesData = stages;
           try {
-            const stagesResponse = await fetch(api.stages.list.path);
-            if (!stagesResponse.ok)
-              throw new Error(`Failed to fetch stages: ${stagesResponse.status}`);
-            const fetchedStages = await stagesResponse.json();
+            const fetchedStages = await apiGet<Stage[]>(api.stages.list.path);
             if (Array.isArray(fetchedStages) && fetchedStages.length > 0)
               stagesData = fetchedStages;
-          } catch (error: any) {
+          } catch (error: unknown) {
             console.error('Error fetching stages:', error);
             if (!stagesData || stagesData.length === 0) {
               toast({
                 title: 'Error fetching stages',
-                description: error.message || 'Could not load stages.',
+                description: error instanceof Error ? error.message : 'Could not load stages.',
                 variant: 'destructive',
               });
               return;


### PR DESCRIPTION
- Replaced direct fetch calls in `useStages`, `useSubStages`, `useTasks`, and related mutations with `apiGet`, `apiPost`, `apiPatch`, and `apiDelete` functions for improved error handling and code consistency.
- This change enhances maintainability and reduces redundancy in API request logic across the application.