### PR TITLE
Add horizontal/vertical board layout toggle and fix all TypeScript er…

### DIFF
--- a/client/src/components/KanbanBoard.tsx
+++ b/client/src/components/KanbanBoard.tsx
@@ -9,12 +9,14 @@ import { KanbanColumnContent } from './KanbanColumnContent';
 import { KanbanDragOverlay } from './KanbanDragOverlay';
 import { ArchiveZone } from './ArchiveZone';
 import { DEFAULT_STAGE_COLORS } from '@shared/constants';
+import { cn } from '@/lib/utils';
 
 export interface KanbanBoardProps {
   tasks: Task[];
   onTaskClick: (task: Task) => void;
   viewMode?: 'detail' | 'summary';
   focusMode?: boolean;
+  boardLayout?: 'vertical' | 'horizontal';
 }
 
 export function KanbanBoard({
@@ -22,6 +24,7 @@ export function KanbanBoard({
   onTaskClick,
   viewMode = 'detail',
   focusMode = false,
+  boardLayout = 'vertical',
 }: KanbanBoardProps) {
   const { data: stages = [] } = useStages();
   const { data: allSubStages = [] } = useSubStages();
@@ -31,7 +34,10 @@ export function KanbanBoard({
   const stageColorMap = useMemo(() => {
     const map = new Map<number, string>();
     sortedStages.forEach((stage, index) =>
-      map.set(stage.id, stage.color || DEFAULT_STAGE_COLORS[index % DEFAULT_STAGE_COLORS.length]),
+      map.set(
+        stage.id,
+        stage.color ?? DEFAULT_STAGE_COLORS[index % DEFAULT_STAGE_COLORS.length] ?? '#6B7280',
+      ),
     );
     return map;
   }, [sortedStages]);
@@ -60,7 +66,12 @@ export function KanbanBoard({
         },
       }}
     >
-      <div className="flex flex-col h-full gap-3 pb-4">
+      <div
+        className={cn(
+          'h-full gap-3 pb-4',
+          boardLayout === 'horizontal' ? 'flex flex-row overflow-x-auto' : 'flex flex-col',
+        )}
+      >
         {sortedStages.map((stage) => {
           const stageColor = stageColorMap.get(stage.id) || DEFAULT_STAGE_COLORS[0];
           const stageTasks = activeTasks.filter((t) => t.stageId === stage.id);
@@ -71,6 +82,7 @@ export function KanbanBoard({
               title={stage.name}
               count={stageTasks.length}
               stageColor={stageColor}
+              boardLayout={boardLayout}
             >
               <KanbanColumnContent
                 stageId={stage.id}

--- a/client/src/components/TaskColumn.tsx
+++ b/client/src/components/TaskColumn.tsx
@@ -8,19 +8,33 @@ interface TaskColumnProps {
   title: string;
   count: number;
   stageColor: string;
+  boardLayout?: 'vertical' | 'horizontal';
   children: React.ReactNode;
 }
 
-export function TaskColumn({ id, title, count, stageColor, children }: TaskColumnProps) {
+export function TaskColumn({
+  id,
+  title,
+  count,
+  stageColor,
+  boardLayout = 'vertical',
+  children,
+}: TaskColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: id,
   });
 
   const isEmpty = count === 0;
 
+  const isHorizontal = boardLayout === 'horizontal';
+
   return (
-    <div className="w-full flex flex-col">
-      {/* Column header - integrated into the column */}
+    <div
+      className={cn(
+        'flex flex-col',
+        isHorizontal ? 'min-w-[280px] max-w-[320px] flex-shrink-0' : 'w-full',
+      )}
+    >
       <div className="flex items-center justify-between px-4 py-3">
         <div className="flex items-center gap-2">
           <div className="w-3 h-3 rounded-full" style={{ backgroundColor: stageColor }} />
@@ -36,12 +50,12 @@ export function TaskColumn({ id, title, count, stageColor, children }: TaskColum
         </Badge>
       </div>
 
-      {/* Column content - taller when empty so it's a clear drop target */}
       <div
         ref={setNodeRef}
         className={cn(
           'p-3 transition-all duration-200 rounded-xl neo-container',
           isEmpty ? 'min-h-[120px]' : 'min-h-[80px]',
+          isHorizontal && 'flex-1 overflow-y-auto',
           isOver && 'bg-primary/5 ring-2 ring-primary/30 scale-[1.01]',
         )}
       >

--- a/client/src/pages/Dashboard/DashboardBottomNav.test.tsx
+++ b/client/src/pages/Dashboard/DashboardBottomNav.test.tsx
@@ -25,8 +25,10 @@ describe('DashboardBottomNav', () => {
   const defaults = {
     viewMode: 'detail' as const,
     focusMode: false,
+    boardLayout: 'vertical' as const,
     onSetViewMode: vi.fn(),
     onToggleFocusMode: vi.fn(),
+    onToggleBoardLayout: vi.fn(),
     onArchive: vi.fn(),
     onAdmin: vi.fn(),
     onExport: vi.fn(),

--- a/client/src/pages/Dashboard/DashboardBottomNav.tsx
+++ b/client/src/pages/Dashboard/DashboardBottomNav.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-confusing-void-expression -- R2 baseline: strict fixes deferred to follow-up tasks */
-import { List, CircleDot, Focus } from 'lucide-react';
+import { List, CircleDot, Focus, Columns, Rows } from 'lucide-react';
 import { CreateTaskDialog } from '@/components/CreateTaskDialog';
 import { cn } from '@/lib/utils';
 import { MoreActionsMenu } from './MoreActionsMenu';
@@ -7,8 +7,10 @@ import { MoreActionsMenu } from './MoreActionsMenu';
 export interface DashboardBottomNavProps {
   viewMode: 'detail' | 'summary';
   focusMode: boolean;
+  boardLayout: 'vertical' | 'horizontal';
   onSetViewMode: (mode: 'detail' | 'summary') => void;
   onToggleFocusMode: () => void;
+  onToggleBoardLayout: () => void;
   onArchive: () => void;
   onAdmin: () => void;
   onExport: () => void;
@@ -18,8 +20,10 @@ export interface DashboardBottomNavProps {
 export function DashboardBottomNav({
   viewMode,
   focusMode,
+  boardLayout,
   onSetViewMode,
   onToggleFocusMode,
+  onToggleBoardLayout,
   onArchive,
   onAdmin,
   onExport,
@@ -74,6 +78,24 @@ export function DashboardBottomNav({
         >
           <Focus className="h-5 w-5 shrink-0" aria-hidden />
           <span className="text-[10px] font-medium">Focus</span>
+        </button>
+
+        <button
+          type="button"
+          className={toggleNavBtn(false)}
+          onClick={onToggleBoardLayout}
+          aria-label={
+            boardLayout === 'vertical' ? 'Switch to horizontal board' : 'Switch to vertical board'
+          }
+        >
+          {boardLayout === 'vertical' ? (
+            <Columns className="h-5 w-5 shrink-0" aria-hidden />
+          ) : (
+            <Rows className="h-5 w-5 shrink-0" aria-hidden />
+          )}
+          <span className="text-[10px] font-medium">
+            {boardLayout === 'vertical' ? 'Horiz' : 'Vert'}
+          </span>
         </button>
 
         <MoreActionsMenu

--- a/client/src/pages/Dashboard/DashboardContent.test.tsx
+++ b/client/src/pages/Dashboard/DashboardContent.test.tsx
@@ -45,6 +45,7 @@ describe('DashboardContent', () => {
     filteredTasks: [] as Task[],
     focusMode: false,
     viewMode: 'detail' as const,
+    boardLayout: 'vertical' as const,
     searchQuery: '',
     onTaskClick: vi.fn(),
   };

--- a/client/src/pages/Dashboard/DashboardContent.tsx
+++ b/client/src/pages/Dashboard/DashboardContent.tsx
@@ -10,6 +10,7 @@ export interface DashboardContentProps {
   filteredTasks: Task[];
   focusMode: boolean;
   viewMode: 'detail' | 'summary';
+  boardLayout: 'vertical' | 'horizontal';
   searchQuery: string;
   onTaskClick: (task: Task) => void;
 }
@@ -19,6 +20,7 @@ export function DashboardContent({
   filteredTasks,
   focusMode,
   viewMode,
+  boardLayout,
   searchQuery,
   onTaskClick,
 }: DashboardContentProps) {
@@ -47,6 +49,7 @@ export function DashboardContent({
               onTaskClick={onTaskClick}
               viewMode={viewMode}
               focusMode={focusMode}
+              boardLayout={boardLayout}
             />
           </div>
         ) : (

--- a/client/src/pages/Dashboard/DashboardHeader.test.tsx
+++ b/client/src/pages/Dashboard/DashboardHeader.test.tsx
@@ -32,8 +32,9 @@ describe('DashboardHeader', () => {
     const onToggleSearch = vi.fn();
     render(<DashboardHeader {...defaults} onToggleSearch={onToggleSearch} />);
 
-    const buttons = screen.getAllByRole('button');
-    fireEvent.click(buttons[0]);
+    const firstBtn = screen.getAllByRole('button').at(0);
+    if (!firstBtn) throw new Error('Expected at least one button');
+    fireEvent.click(firstBtn);
     expect(onToggleSearch).toHaveBeenCalledOnce();
   });
 
@@ -49,8 +50,8 @@ describe('DashboardHeader', () => {
     const onClearSearch = vi.fn();
     render(<DashboardHeader {...defaults} showSearch={true} onClearSearch={onClearSearch} />);
 
-    const buttons = screen.getAllByRole('button');
-    const clearBtn = buttons[buttons.length - 1];
+    const clearBtn = screen.getAllByRole('button').at(-1);
+    if (!clearBtn) throw new Error('Expected at least one button');
     fireEvent.click(clearBtn);
     expect(onClearSearch).toHaveBeenCalledOnce();
   });

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -27,6 +27,7 @@ export default function Dashboard(_props: DashboardProps) {
   const [showSearch, setShowSearch] = useState(false);
   const [viewMode, setViewMode] = useState<'detail' | 'summary'>('summary');
   const [focusMode, setFocusMode] = useState(false);
+  const [boardLayout, setBoardLayout] = useState<'vertical' | 'horizontal'>('vertical');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   const { data: stages = [] } = useStages();
@@ -106,6 +107,7 @@ export default function Dashboard(_props: DashboardProps) {
         filteredTasks={filteredTasks}
         focusMode={focusMode}
         viewMode={viewMode}
+        boardLayout={boardLayout}
         searchQuery={searchQuery}
         onTaskClick={handleTaskClick}
       />
@@ -113,9 +115,13 @@ export default function Dashboard(_props: DashboardProps) {
       <DashboardBottomNav
         viewMode={viewMode}
         focusMode={focusMode}
+        boardLayout={boardLayout}
         onSetViewMode={setViewMode}
         onToggleFocusMode={() => {
           setFocusMode(!focusMode);
+        }}
+        onToggleBoardLayout={() => {
+          setBoardLayout(boardLayout === 'vertical' ? 'horizontal' : 'vertical');
         }}
         onArchive={() => (window.location.href = ROUTES.ARCHIVE)}
         onAdmin={() => (window.location.href = ROUTES.ADMIN)}

--- a/client/src/pages/Dashboard/use-filtered-tasks.test.ts
+++ b/client/src/pages/Dashboard/use-filtered-tasks.test.ts
@@ -66,7 +66,7 @@ describe('useFilteredTasks', () => {
       }),
     );
     expect(result.current).toHaveLength(1);
-    expect(result.current[0].title).toBe('Fix login bug');
+    expect(result.current.at(0)?.title).toBe('Fix login bug');
   });
 
   it('filters tasks by description matching the search query', () => {
@@ -84,7 +84,7 @@ describe('useFilteredTasks', () => {
       }),
     );
     expect(result.current).toHaveLength(1);
-    expect(result.current[0].id).toBe(1);
+    expect(result.current.at(0)?.id).toBe(1);
   });
 
   it('search is case-insensitive', () => {

--- a/docs/GMAIL_REFRESH_TOKEN.md
+++ b/docs/GMAIL_REFRESH_TOKEN.md
@@ -1,0 +1,165 @@
+# Regenerating the Gmail refresh token
+
+Follow these steps when the app logs `invalid_grant`. This means Google
+rejected the stored refresh token and you need a new one.
+
+Common reasons a refresh token stops working:
+
+- The OAuth consent screen is in **Testing** mode (tokens expire after 7 days).
+- Someone revoked app access from the Google Account.
+- The account password was changed.
+- The client ID or secret was rotated without re-issuing the token.
+
+---
+
+## What you need before you start
+
+- Access to the [Google Cloud Console](https://console.cloud.google.com/) for
+  the project that owns the OAuth client.
+- The **GOOGLE_CLIENT_ID** and **GOOGLE_CLIENT_SECRET** values currently set in
+  your deployment (Railway, `.env`, etc.). You are not changing these — only the
+  refresh token.
+- The ability to sign in to the Gmail account the app monitors
+  (the `GMAIL_MAILBOX` address).
+
+---
+
+## Step 1 — Open the OAuth Playground
+
+Go to <https://developers.google.com/oauthplayground/>.
+
+---
+
+## Step 2 — Tell the Playground to use your own OAuth client
+
+By default the Playground uses Google's demo client, which will not work for
+your app.
+
+1. Click the **gear icon** (⚙ OAuth 2.0 configuration) in the top-right
+   corner.
+2. Check **"Use your own OAuth credentials"**.
+3. Paste your **GOOGLE_CLIENT_ID** into the "OAuth Client ID" field.
+4. Paste your **GOOGLE_CLIENT_SECRET** into the "OAuth Client secret" field.
+
+> If you do not know these values, find them in
+> [Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)
+> under the OAuth 2.0 Client ID the app uses, or in your deployment's
+> environment variables.
+
+---
+
+## Step 3 — Make sure the Playground's redirect URI is authorized
+
+The Playground sends users back to
+`https://developers.google.com/oauthplayground` after consent.
+Your OAuth client must list this as an authorized redirect URI.
+
+1. In [Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials),
+   open your OAuth client.
+2. Under **Authorized redirect URIs**, check that
+   `https://developers.google.com/oauthplayground` is listed.
+3. If it is missing, click **Add URI**, paste the URL, and save.
+
+---
+
+## Step 4 — Select the Gmail scope
+
+Back in the Playground, on the left side under **Step 1 — Select & authorize
+APIs**:
+
+1. Scroll to **Gmail API v1** and expand it, or type the scope manually in the
+   "Input your own scopes" box:
+
+   ```
+   https://www.googleapis.com/auth/gmail.readonly
+   ```
+
+2. Click **Authorize APIs**.
+
+---
+
+## Step 5 — Sign in and grant consent
+
+1. A Google sign-in page opens. Sign in with the **Gmail account the app
+   monitors** (the `GMAIL_MAILBOX` address).
+2. If you see a warning that the app is unverified, click
+   **Advanced → Go to \<app name\> (unsafe)**. This is expected for apps whose
+   consent screen is in Testing mode.
+3. Review the permissions and click **Allow** (or **Continue**).
+
+You are redirected back to the Playground with an **authorization code**
+filled in.
+
+---
+
+## Step 6 — Exchange the code for tokens
+
+1. In the Playground, click **Exchange authorization code for tokens**
+   (Step 2 in the left panel).
+2. The Playground shows a JSON response containing `access_token` and
+   `refresh_token`.
+3. Copy the **refresh_token** value (the long string — do not include the
+   quotes).
+
+---
+
+## Step 7 — Update your deployment
+
+Replace the old `GOOGLE_REFRESH_TOKEN` with the value you just copied.
+
+**Railway:**
+
+1. Open your project in the [Railway dashboard](https://railway.app/dashboard).
+2. Select the service that runs the server.
+3. Go to **Variables**.
+4. Find `GOOGLE_REFRESH_TOKEN`, click it, paste the new value, and save.
+5. Railway will automatically redeploy. Wait for the new deployment to go
+   healthy.
+
+**Local `.env` file (development):**
+
+Open `.env` and replace the line:
+
+```
+GOOGLE_REFRESH_TOKEN=<old value>
+```
+
+with:
+
+```
+GOOGLE_REFRESH_TOKEN=<new value>
+```
+
+Restart the dev server.
+
+---
+
+## Step 8 — Verify it works
+
+1. Check the deployment logs. The `invalid_grant` errors should stop.
+2. Send a test email that matches the Gmail filter so it gets the
+   `kanbando-trigger` label.
+3. Confirm the webhook fires and processes the message (look for
+   `webhook.sync_completed` in the logs).
+
+---
+
+## Preventing this from happening again
+
+| Problem | Fix |
+|---------|-----|
+| Tokens expire every 7 days | Publish the OAuth consent screen. Go to [Cloud Console → OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent) and set the publishing status to **In production** (External) or **Internal** (Workspace orgs). Published apps issue refresh tokens that do not expire on a timer. |
+| User revokes access | Unavoidable — re-run this guide if it happens. |
+| Password change invalidates token | Re-run this guide after any password change on the monitored account. |
+
+---
+
+## Quick reference
+
+| Item | Value |
+|------|-------|
+| OAuth Playground URL | <https://developers.google.com/oauthplayground/> |
+| Playground redirect URI (must be in your client) | `https://developers.google.com/oauthplayground` |
+| Required scope | `https://www.googleapis.com/auth/gmail.readonly` |
+| Env var to update | `GOOGLE_REFRESH_TOKEN` |
+| Related setup doc | [`GMAIL_PUBSUB_SETUP.md`](../GMAIL_PUBSUB_SETUP.md) (sections 5 and 10) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/express": "4.17.21",
         "@types/node": "20.19.27",
+        "@types/pg": "^8.20.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@types/supertest": "^7.2.0",
@@ -3302,10 +3303,22 @@
       "version": "20.19.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -8237,7 +8250,7 @@
       "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
       "license": "MIT"
     },
-    "node_modules/pg/node_modules/pg-types": {
+    "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
@@ -8251,45 +8264,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pg/node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pgpass": {
@@ -8479,6 +8453,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -10317,7 +10330,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/express": "4.17.21",
     "@types/node": "20.19.27",
+    "@types/pg": "^8.20.0",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@types/supertest": "^7.2.0",

--- a/server/jobs/inbound-email-worker.ts
+++ b/server/jobs/inbound-email-worker.ts
@@ -42,7 +42,7 @@ const priorityMap: Record<string, NonNullable<InsertTask['priority']>> = {
 };
 
 function mapPriority(priority: string | null | undefined): NonNullable<InsertTask['priority']> {
-  return priority ? priorityMap[priority] : TASK_PRIORITY.NORMAL;
+  return (priority ? priorityMap[priority] : undefined) ?? TASK_PRIORITY.NORMAL;
 }
 
 function buildTaskInsert(input: {
@@ -159,7 +159,7 @@ export async function processOneInboundRow(): Promise<void> {
       traceContext: {
         inboundRowId: fresh.id,
         gmailMessageId: fresh.gmailMessageId,
-        historyIdSeen: fresh.historyIdSeen,
+        historyIdSeen: fresh.historyIdSeen ?? undefined,
         normalizedBodyHash: bodyHash,
       },
     });

--- a/server/langgraph/email-task-graph.ts
+++ b/server/langgraph/email-task-graph.ts
@@ -66,7 +66,7 @@ function makeStructuredInvoker(apiKey: string, modelName: string) {
   const model = new ChatOpenAI({ model: modelName, apiKey });
   return async function structuredInvoke<T>(schema: z.ZodType<T>, prompt: string): Promise<T> {
     const runnable = model.withStructuredOutput(schema);
-    return runnable.invoke(prompt);
+    return runnable.invoke(prompt) as Promise<T>;
   };
 }
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -375,7 +375,7 @@ describe('IStorage contract', () => {
       const s1Subs = await storage.getSubStagesByStage(parentStageId);
 
       expect(s1Subs).toHaveLength(1);
-      expect(s1Subs[0].name).toBe('S1-sub');
+      expect(s1Subs[0]!.name).toBe('S1-sub');
     });
 
     it('returns an empty array for a stageId with no sub-stages', async () => {
@@ -462,8 +462,8 @@ describe('IStorage contract', () => {
       const task = await storage.createTask(makeTaskInput(stageId));
 
       expect(task.history).toHaveLength(1);
-      expect(task.history![0].status).toBe(TASK_STATUS.BACKLOG);
-      expect(task.history![0].timestamp).toBeTruthy();
+      expect(task.history![0]!.status).toBe(TASK_STATUS.BACKLOG);
+      expect(task.history![0]!.timestamp).toBeTruthy();
     });
 
     it('infers status from stage name when not explicitly set', async () => {
@@ -471,7 +471,7 @@ describe('IStorage contract', () => {
       const task = await storage.createTask(makeTaskInput(doneStage.id));
 
       expect(task.status).toBe(TASK_STATUS.DONE);
-      expect(task.history![0].status).toBe(TASK_STATUS.DONE);
+      expect(task.history![0]!.status).toBe(TASK_STATUS.DONE);
     });
 
     it('uses explicit status over inferred stage status', async () => {
@@ -491,7 +491,7 @@ describe('IStorage contract', () => {
       const tasks = await storage.getTasks();
 
       expect(tasks).toHaveLength(1);
-      expect(tasks[0].title).toBe('Active');
+      expect(tasks[0]!.title).toBe('Active');
     });
 
     it('returns archived tasks from getArchivedTasks()', async () => {
@@ -502,7 +502,7 @@ describe('IStorage contract', () => {
       const archived = await storage.getArchivedTasks();
 
       expect(archived).toHaveLength(1);
-      expect(archived[0].title).toBe('Old');
+      expect(archived[0]!.title).toBe('Old');
     });
 
     it('returns tasks ordered by id', async () => {
@@ -511,8 +511,8 @@ describe('IStorage contract', () => {
 
       const tasks = await storage.getTasks();
 
-      expect(tasks[0].title).toBe('First');
-      expect(tasks[1].title).toBe('Second');
+      expect(tasks[0]!.title).toBe('First');
+      expect(tasks[1]!.title).toBe('Second');
     });
 
     it('filters tasks by stageId', async () => {
@@ -523,7 +523,7 @@ describe('IStorage contract', () => {
       const s1Tasks = await storage.getTasksByStage(stageId);
 
       expect(s1Tasks).toHaveLength(1);
-      expect(s1Tasks[0].title).toBe('S1');
+      expect(s1Tasks[0]!.title).toBe('S1');
     });
 
     it('getTasksByStage excludes archived tasks', async () => {
@@ -587,7 +587,7 @@ describe('IStorage contract', () => {
       const updated = await storage.updateTask(task.id, { status: TASK_STATUS.IN_PROGRESS });
 
       expect(updated!.history).toHaveLength(2);
-      expect(updated!.history![1].status).toBe(TASK_STATUS.IN_PROGRESS);
+      expect(updated!.history![1]!.status).toBe(TASK_STATUS.IN_PROGRESS);
     });
 
     it('does not append history when status is unchanged', async () => {
@@ -642,8 +642,8 @@ describe('IStorage contract', () => {
 
       const archived = await storage.archiveTask(task.id);
 
-      const lastEntry = archived!.history![archived!.history!.length - 1];
-      expect(lastEntry.note).toBe('Archived');
+      const lastEntry = archived!.history!.at(-1);
+      expect(lastEntry!.note).toBe('Archived');
     });
 
     it('returns undefined when archiving a non-existent task', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
+    "target": "es2022",
     "module": "ESNext",
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
…rors

Add a board layout toggle to the bottom nav that switches between vertical (current stacked rows) and horizontal (side-by-side columns with horizontal scroll) board layouts. Fix all pre-existing TypeScript errors: add target es2022 to tsconfig to resolve MapIterator downlevelIteration issues, install @types/pg, handle noUncheckedIndexedAccess array access in tests, fix null-vs-undefined mismatch in inbound-email-worker, add fallback for priorityMap lookup, and cast withStructuredOutput return type.

Made-with: Cursor